### PR TITLE
docs(readme): fix typos in usage example, enable JS syntax highlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,22 @@
 # find-git-root
-Recursively find the closest .git/ and return repo path
+Recursively find the closest `.git/` and return repo path
 
 # Installation
 
-    $ npm install find-git-root
+```bash
+$ npm install find-git-root
+```
 
 # Usage
+```javascript
+'use strict'
 
-    'use strict'
+const findGitRoot = require('find-git-root')
 
-    const findGitRoot = require('find-git-root)
+// git clone url /home/you/repo
+const root = findGitRoot('/home/you/repo/somedir/somefile')
+// => /home/you/repo/.git
 
-    // git clone url /home/you/repo
-    const root = findGitRoot('/home/you/repo/somedir/somefile')
-    // => /home/you/repo/.git
-
-    const root = findGitRoot('/home/you/repo/somedir')
-    // => /home/you/repo/.git
+const root = findGitRoot('/home/you/repo/somedir')
+// => /home/you/repo/.git
+```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "find-git-root",
   "version": "1.0.0",
-  "description": "ecursively find the closest .git/",
+  "description": "recursively find the closest .git/",
   "main": "index.js",
   "scripts": {
     "test": "mocha",


### PR DESCRIPTION
Hi @banyudu

I've noticed a couple of typos in description and usage example. Here's the patch.