### PR TITLE
Fix finding git root for POSIX-delimited path on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ function findGitRoot(start) {
     if (start[start.length - 1] !== path.sep) {
       start += path.sep
     }
+    start = path.normalize(start)
     start = start.split(path.sep)
   }
   if (!start.length) {

--- a/test/index.js
+++ b/test/index.js
@@ -16,4 +16,9 @@ describe('findGitRoot', () => {
     assert.equal(findGitRoot(), root)
     assert.equal(findGitRoot(null), root)
   })
+  if (process.platform === 'win32') {
+    it('Should be ok handling POSIX delimiters on Windows', () => {
+        assert.equal(findGitRoot(__filename.replace(/\\/g, path.posix.sep)), root)
+    })
+  }
 })


### PR DESCRIPTION
`find-git-root` assumes that paths are delimited with the current platforms delimiter.
When providing a path with POSIX delimiters (`/`) to `find-git-root` on Windows the result is simply `.git`, which is incorrect.

e.g. `findGitRoot("C:/Users/Caleb/Documents/GitHub/find-git-root/test/index.js")`
![image](https://user-images.githubusercontent.com/25311843/75035325-1815a500-5514-11ea-9dad-f233f00ef250.png)

The docs for [path.sep](https://nodejs.org/api/path.html#path_path_sep) mention that Node accepts both `\` and `/` on Windows.

I ran into this issue because [shelljs's find() function returns POSIX delimiters for every platform](https://github.com/shelljs/shelljs/blob/master/src/find.js#L35).
![image](https://user-images.githubusercontent.com/25311843/75035514-82c6e080-5514-11ea-8b0c-05f17b15d255.png)

I may look at submitting a pull request there too.